### PR TITLE
Reorganize coordinator <=> worker communication

### DIFF
--- a/orchestrator/src/lib.rs
+++ b/orchestrator/src/lib.rs
@@ -1,5 +1,4 @@
+pub mod coordinator;
 mod message;
 pub mod sandbox;
 pub mod worker;
-pub mod coordinator;
-

--- a/orchestrator/src/main.rs
+++ b/orchestrator/src/main.rs
@@ -7,6 +7,8 @@ pub async fn main() {
     let args: Vec<String> = env::args().collect();
 
     // Panics messages are written to stderr.
-    let project_dir = args.get(1).expect("Please specify project directory as the first argument");
+    let project_dir = args
+        .get(1)
+        .expect("Please specify project directory as the first argument");
     listen(project_dir.into()).await.unwrap();
 }

--- a/orchestrator/src/sandbox.rs
+++ b/orchestrator/src/sandbox.rs
@@ -81,3 +81,8 @@ pub struct CompileResponse {
     pub stderr: String,
 }
 
+#[derive(Debug, Clone)]
+pub struct CompileResponse2 {
+    pub success: bool,
+    pub code: String,
+}


### PR DESCRIPTION
In broad strokes, this...

- Moves the lifting / lowering logic out of a centralized location and puts it nearer to each specific command.
- Removes the concept of the "job" message and its vector of subcommands in favor of single messages.
- Flattens the enums sent between the two components.
- Introduces the `Multiplexed` type and demultiplexer.

As before, these are my ideas. I've liberally used `unwrap` / `expect` / `panic!` to get things into the shape I want. Happy to discuss details.