### PR TITLE
Further report errors

### DIFF
--- a/orchestrator/Cargo.lock
+++ b/orchestrator/Cargo.lock
@@ -101,6 +101,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,6 +232,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0656e7e3ffb70f6c39b3c2a86332bb74aa3c679da781642590f3c1118c5045"
 dependencies = [
  "doc-comment",
+ "futures-core",
+ "pin-project",
  "snafu-derive",
 ]
 

--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3"
 tokio = { version = "1.25", features = ["sync", "rt", "io-std", "io-util", "fs", "process", "macros", "time" ] }
-snafu = "0.7.4"
+snafu = { version = "0.7.4", features = ["futures"] }
 strum = { version = "0.24.1", features = ["derive"] }
 tokio-util = { version = "0.7.7", features = ["io", "io-util"] }
 tokio-stream = "0.1.12"

--- a/orchestrator/src/lib.rs
+++ b/orchestrator/src/lib.rs
@@ -2,3 +2,13 @@ pub mod coordinator;
 mod message;
 pub mod sandbox;
 pub mod worker;
+
+trait DropErrorDetailsExt<T> {
+    fn drop_error_details(self) -> Result<T, tokio::sync::mpsc::error::SendError<()>>;
+}
+
+impl<T, E> DropErrorDetailsExt<T> for Result<T, tokio::sync::mpsc::error::SendError<E>> {
+    fn drop_error_details(self) -> Result<T, tokio::sync::mpsc::error::SendError<()>> {
+        self.map_err(|_| tokio::sync::mpsc::error::SendError(()))
+    }
+}

--- a/orchestrator/src/main.rs
+++ b/orchestrator/src/main.rs
@@ -1,14 +1,15 @@
+use orchestrator::worker::{listen, Error};
 use std::env;
 
-use orchestrator::worker::listen;
-
 #[tokio::main(flavor = "current_thread")]
-pub async fn main() {
+#[snafu::report]
+pub async fn main() -> Result<(), Error> {
     let args: Vec<String> = env::args().collect();
 
     // Panics messages are written to stderr.
     let project_dir = args
         .get(1)
         .expect("Please specify project directory as the first argument");
-    listen(project_dir.into()).await.unwrap();
+
+    listen(project_dir.into()).await
 }

--- a/orchestrator/src/message.rs
+++ b/orchestrator/src/message.rs
@@ -89,9 +89,6 @@ pub struct ExecuteCommandRequest {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ExecuteCommandResponse(pub ());
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct StreamCommandResponse(pub ());
-
 pub trait OneToOneResponse {
     type Response;
 }

--- a/orchestrator/src/worker.rs
+++ b/orchestrator/src/worker.rs
@@ -14,13 +14,12 @@ use tokio::{
     task::JoinSet,
 };
 
-use crate::DropErrorDetailsExt;
 use crate::{
     message::{
         CoordinatorMessage, ExecuteCommandRequest, ExecuteCommandResponse, JobId, Multiplexed,
         ReadFileRequest, ReadFileResponse, WorkerMessage, WriteFileRequest, WriteFileResponse,
     },
-    JoinSetExt,
+    DropErrorDetailsExt, JoinSetExt,
 };
 
 type CommandRequest = (JobId, ExecuteCommandRequest, Arc<Notify>);

--- a/orchestrator/src/worker.rs
+++ b/orchestrator/src/worker.rs
@@ -237,7 +237,7 @@ async fn handle_write_file(
 ) -> Result<WriteFileResponse, WriteFileError> {
     use write_file_error::*;
 
-    let path = parse_working_dir(Some(req.path), &project_dir);
+    let path = parse_working_dir(Some(req.path), project_dir);
 
     // Create intermediate directories.
     if let Some(parent_dir) = path.parent() {
@@ -278,7 +278,7 @@ async fn handle_read_file(
 ) -> Result<ReadFileResponse, ReadFileError> {
     use read_file_error::*;
 
-    let path = parse_working_dir(Some(req.path), &project_dir);
+    let path = parse_working_dir(Some(req.path), project_dir);
 
     let content = fs::read(&path)
         .await
@@ -301,8 +301,8 @@ pub enum ReadFileError {
 }
 
 // Current working directory defaults to project dir unless specified otherwise.
-fn parse_working_dir(cwd: Option<String>, project_path: &Path) -> PathBuf {
-    let mut final_path = project_path.to_path_buf();
+fn parse_working_dir(cwd: Option<String>, project_path: impl Into<PathBuf>) -> PathBuf {
+    let mut final_path = project_path.into();
     if let Some(path) = cwd {
         // Absolute path will replace final_path.
         final_path.push(path)

--- a/orchestrator/src/worker.rs
+++ b/orchestrator/src/worker.rs
@@ -496,7 +496,7 @@ fn stream_stdio(
             }
 
             coordinator_tx_out
-                .send(<Result<_>>::Ok(WorkerMessage::StdoutPacket(buffer)))
+                .send_ok(WorkerMessage::StdoutPacket(buffer))
                 .await
                 .context(UnableToSendStdoutPacketSnafu)?;
         }
@@ -519,7 +519,7 @@ fn stream_stdio(
             }
 
             coordinator_tx_err
-                .send(<Result<_>>::Ok(WorkerMessage::StderrPacket(buffer)))
+                .send_ok(WorkerMessage::StderrPacket(buffer))
                 .await
                 .context(UnableToSendStderrPacketSnafu)?;
         }


### PR DESCRIPTION
This attempts to capture all errors from the worker and report them in some way. If an error occurs when we have a job ID, we now send a `WorkerMessage::Error` response. This differs from the previous implementation as it allows for an error to occur outside of a request/response cycle. For example, an error could occur while we are sitting and watching the streaming output.

As always, this code is open for pushback, feedback, and further discussion!